### PR TITLE
feat(module): add resolver related module and examples

### DIFF
--- a/examples/dns-inbound-resolver/README.md
+++ b/examples/dns-inbound-resolver/README.md
@@ -1,0 +1,59 @@
+# Inbound endpoint
+
+Configuration in this directory creates these resource:
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan -var-file=variables.json
+$ terraform apply -var-file=variables.json
+```
+
+Run `terraform destroy -var-file=variables.json` when you don't need these resources.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| Terraform | >= 1.3.0 |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+<!-- markdownlint-disable MD013 -->
+| Name | Source | Version |
+|------|--------|---------|
+| vpc_network | [terraform-huaweicloud-vpc](https://github.com/terraform-huaweicloud-modules/terraform-huaweicloud-vpc) | v1.2.0 |
+| dns_resolver | [../../modules/dns-resolver](../../modules/dns-resolver/README.md) | N/A |
+<!-- markdownlint-enable MD013 -->
+
+## Resources
+
+| Name | Type |
+|------|------|
+| data.huaweicloud_availability_zones.this | data source |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+| Name | Description | Value |
+|------|-------------|-------|
+| region_name | The region where the resources are located | `"cn-north-4"` |
+| enterprise_project_id | Used to specify whether the resource is created under the enterprise project (this parameter is only valid for enterprise users) | `"0"` |
+| vpc_name | The name of the VPC to which the endpoint belongs | `"VPC-Test-Inbound"` |
+| vpc_cidr | The CIDR block of the VPC to which the endpoint belongs | `"172.16.0.0/16"` |
+| subnets_configuration | The configuration for the subnets to which the endpoint belongs | <pre>[<br>  {<br>    "name": "Subnet-Inbound",<br>    "cidr": "192.16.0.0/24"<br>  }<br>]</pre> |
+| endpoint_name | The name of the endpoint | `"Endpoint-Test"` |
+| endpoint_type | The type of the endpoint | `"inbound"` |
+| endpoint_ip_addresses | The list of the IP addresses of the endpoint | <pre>[<br>  "172.16.0.10",<br>  "172.16.0.11"<br>]</pre> |
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| endpoint_id | The ID of the inbound endpoint |
+| endpoint_assignments | The list of IP addresses assigned to the inbound endpoint |

--- a/examples/dns-inbound-resolver/main.tf
+++ b/examples/dns-inbound-resolver/main.tf
@@ -1,0 +1,31 @@
+provider "huaweicloud" {
+  region = var.region_name
+}
+
+data "huaweicloud_availability_zones" "this" {}
+
+module "vpc_network" {
+  source = "github.com/terraform-huaweicloud-modules/terraform-huaweicloud-vpc?ref=v1.2.0"
+
+  enterprise_project_id = var.enterprise_project_id
+  availability_zone     = try(data.huaweicloud_availability_zones.this.names[0], "")
+
+  vpc_name              = var.vpc_name
+  vpc_cidr              = var.vpc_cidr
+  subnets_configuration = var.subnets_configuration
+
+  is_security_group_create = false
+}
+
+module "dns_resolver" {
+  source = "../../modules/dns-resolver"
+
+  endpoint_name = var.endpoint_name
+  endpoint_type = var.endpoint_type
+
+  # Assign two IPs to a subnet.
+  endpoint_assignments = try(module.vpc_network.subnet_ids[0], "") != "" ? [for v in var.endpoint_ip_addresses : {
+    "subnet_id" : module.vpc_network.subnet_ids[0],
+    "ip_address" : v
+  }] : []
+}

--- a/examples/dns-inbound-resolver/outputs.tf
+++ b/examples/dns-inbound-resolver/outputs.tf
@@ -1,0 +1,11 @@
+output "endpoint_id" {
+  description = "The ID of the endpoint"
+
+  value = module.dns_resolver.endpoint_id
+}
+
+output "endpoint_assignments" {
+  description = "The list of IP addresses assigned to the endpoint"
+
+  value = module.dns_resolver.endpoint_assignments
+}

--- a/examples/dns-inbound-resolver/variables.json
+++ b/examples/dns-inbound-resolver/variables.json
@@ -1,0 +1,18 @@
+{
+    "region_name": "cn-north-4",
+    "enterprise_project_id": "0",
+    "vpc_name": "VPC-Test-Inbound",
+    "vpc_cidr": "172.16.0.0/16",
+    "subnets_configuration": [
+        {
+            "name": "Subnet-Inbound",
+            "cidr": "172.16.0.0/24"
+        }
+    ],
+    "endpoint_name": "Endpoint-Test",
+    "endpoint_type": "inbound",
+    "endpoint_ip_addresses": [
+        "172.16.0.10",
+        "172.16.0.11"
+    ]
+}

--- a/examples/dns-inbound-resolver/variables.tf
+++ b/examples/dns-inbound-resolver/variables.tf
@@ -1,0 +1,58 @@
+######################################################################
+# Public configurations
+######################################################################
+
+variable "region_name" {
+  type        = string
+  description = "The region where the resources are located"
+}
+
+variable "enterprise_project_id" {
+  type        = string
+  description = "Used to specify whether the resource is created under the enterprise project (this parameter is only valid for enterprise users)"
+
+  default = ""
+}
+
+######################################################################
+# Configurations of VPC resource and related resources
+######################################################################
+
+variable "vpc_name" {
+  type        = string
+  description = "The name of the VPC to which the endpoint belongs"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "The CIDR block of the VPC to which the endpoint belongs"
+}
+
+variable "subnets_configuration" {
+  type = list(object({
+    name = string
+    cidr = string
+  }))
+
+  description = "The configuration for the subnets to which the endpoint belongs"
+}
+
+######################################################################
+# Configurations endpoint resource
+######################################################################
+
+variable "endpoint_name" {
+  type        = string
+  description = "The name of the endpoint"
+}
+
+variable "endpoint_type" {
+  type        = string
+  description = "The type of the endpoint"
+}
+
+variable "endpoint_ip_addresses" {
+  type = list(string)
+
+  description = "The list of the IP addresses of the endpoint"
+}

--- a/examples/dns-inbound-resolver/versions.tf
+++ b/examples/dns-inbound-resolver/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}

--- a/examples/dns-outbound-resolver/README.md
+++ b/examples/dns-outbound-resolver/README.md
@@ -1,0 +1,70 @@
+# Outbound endpoint and resolver rules
+
+Configuration in this directory creates these resource:
+
++ Two VPC
++ A subnet under the VPC
++ A resolver rule under the endpoint
++ Three VPCs are associated with the zone and resolver rules
++ A DNS zone
++ Two rules are associated with two VPCs respectively
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan -var-file=variables.json
+$ terraform apply -var-file=variables.json
+```
+
+Run `terraform destroy -var-file=variables.json` when you don't need these resources.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| Terraform | >= 1.3.0 |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+<!-- markdownlint-disable MD013 -->
+| Name | Source | Version |
+|------|--------|---------|
+| vpc_network | [terraform-huaweicloud-vpc](https://github.com/terraform-huaweicloud-modules/terraform-huaweicloud-vpc) | v1.2.0 |
+| dns_zone | [../../modules/dns-zone](../../modules/dns-zone/README.md) | N/A |
+| dns_resolver | [../../modules/dns-resolver](../../modules/dns-resolver/README.md) | N/A |
+<!-- markdownlint-enable MD013 -->
+
+## Resources
+
+| Name | Type |
+|------|------|
+| data.huaweicloud_availability_zones.this | data source |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+| Name | Description | Value |
+|------|-------------|-------|
+| region_name | The region where the resources are located | `"cn-north-4"` |
+| enterprise_project_id | Used to specify whether the resource is created under the enterprise project (this parameter is only valid for enterprise users) | `"0"` |
+| vpc_network_configurations | The configuration VPCs and subnets to which the endpoint or resolver rule belongs | <pre>[<br>  {<br>    "vpc_name": "VPC-Test-Zone",<br>    "vpc_cidr": "172.16.0.0/16",<br>    "subnets_configuration": [<br>      {<br>        "name": "Subnet-Test",<br>        "cidr": "172.16.0.0/24"<br>      }<br>    ]<br>  },<br> {<br>    "vpc_name": "VPC-Test-1",<br>    "vpc_cidr": "172.16.0.0/16",<br>    "subnets_configuration": [<br>      {<br>        "name": "Subnet-1-1",<br>        "cidr": "172.16.0.0/24"<br>      }<br>    ]<br>  },<br>  {<br>    "vpc_name": "VPC-Test-1",<br>    "vpc_cidr": "172.16.0.0/16",<br>    "subnets_configuration": [<br>      {<br>        "name": "Subnet-1-1",<br>        "cidr": "172.16.0.0/24"<br>      }<br>    ]<br>  }<br>]</pre> |
+| zone_name | The name of the DNS zone | `"resolver.zone.name.com."` |
+| zone_type | The type of the DNS zone | `"private"` |
+| endpoint_name | The name of the endpoint | `"Endpoint-Test"` |
+| endpoint_type | The type of the endpoint | `"outbound"` |
+| endpoint_ip_addresses | The list of the IP addresses of the endpoint | <pre>[<br>  "172.16.0.10",<br>  "172.16.0.11"<br>]</pre> |
+| resolver_rules_configuration | The configuration list of the resolver rules |  <pre>[<br>  {<br>    "name": "Rule-Test",<br>    "ip_addresses": [<br>      "192.168.2.100",<br>      "192.168.2.101"<br>    ]<br>  },<br>  {<br>    "name": "Rule-Test2",<br>    "ip_addresses": [<br>      "172.168.2.100",<br>      "172.168.2.101"<br>    ]<br>  }<br>]</pre> |
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| endpoint_id | The ID of the outbound endpoint |
+| endpoint_assignments | The list of IP addresses assigned to the outbound endpoint |
+| resolver_rules_configuration | The basic configuration list of the resolver rules |
+| resolver_rules_associate_vpcs_configuration | The VPCs configuration for the resolver rules |

--- a/examples/dns-outbound-resolver/main.tf
+++ b/examples/dns-outbound-resolver/main.tf
@@ -1,0 +1,59 @@
+provider "huaweicloud" {
+  region = var.region_name
+}
+
+data "huaweicloud_availability_zones" "this" {}
+
+# Create three VPCs, and the first one is used for zone.
+module "vpc_network" {
+  for_each = { for index, config in var.vpc_network_configurations : index => config }
+
+  source = "github.com/terraform-huaweicloud-modules/terraform-huaweicloud-vpc?ref=v1.2.0"
+
+  enterprise_project_id = var.enterprise_project_id
+  availability_zone     = try(data.huaweicloud_availability_zones.this.names[0], "")
+
+  vpc_name              = each.value.vpc_name
+  vpc_cidr              = each.value.vpc_cidr
+  subnets_configuration = each.value.subnets_configuration
+
+  is_security_group_create = false
+}
+
+module "dns_zone" {
+  source = "../../modules/dns-zone"
+
+  enterprise_project_id = var.enterprise_project_id
+
+  # Inbound endpoint don't need to create zone.
+  is_zone_create = var.zone_name != ""
+  zone_name      = var.zone_name
+  zone_type      = var.zone_type
+
+  zone_routers = try(module.vpc_network[0].vpc_id, "") != "" ? [
+    {
+      router_id = module.vpc_network[0].vpc_id
+    }
+  ] : []
+}
+
+module "dns_resolver" {
+  source = "../../modules/dns-resolver"
+
+  endpoint_name = var.endpoint_name
+  endpoint_type = var.endpoint_type
+
+  # Assign two IPs to a subnet.
+  endpoint_assignments = try(module.vpc_network[0].subnet_ids[0], "") != "" ? [for v in var.endpoint_ip_addresses : {
+    "subnet_id" : module.vpc_network[0].subnet_ids[0],
+    "ip_address" : v
+  }] : []
+
+  resolver_rules_configuration = [for v in var.resolver_rules_configuration : {
+    "name"        = v.name,
+    "domain_name" = module.dns_zone.zone_name
+    ip_addresses  = v.ip_addresses,
+    # The zone name and resolver rule cannot use the same VPC ID.
+    vpc_ids = [for i, v in module.vpc_network : v.vpc_id if i > 0]
+  }]
+}

--- a/examples/dns-outbound-resolver/outputs.tf
+++ b/examples/dns-outbound-resolver/outputs.tf
@@ -1,0 +1,24 @@
+output "endpoint_id" {
+  description = "The ID of the endpoint"
+
+  value = module.dns_resolver.endpoint_id
+}
+
+output "endpoint_assignments" {
+  description = "The list of IP addresses assigned to the endpoint"
+
+  value = module.dns_resolver.endpoint_assignments
+}
+
+output "resolver_rules_configuration" {
+  description = "The basic configuration list of the resolver rules"
+
+  value = module.dns_resolver.resolver_rules_configuration
+}
+
+output "resolver_rules_associate_vpcs_configuration" {
+  description = "The VPCs configuration for the resolver rules"
+
+  value = module.dns_resolver.resolver_rules_associate_vpcs_configuration
+}
+

--- a/examples/dns-outbound-resolver/variables.json
+++ b/examples/dns-outbound-resolver/variables.json
@@ -1,0 +1,60 @@
+{
+    "region_name": "cn-north-4",
+    "enterprise_project_id": "0",
+    "vpc_network_configurations": [
+        {
+            "vpc_name": "VPC-Test-Zone",
+            "vpc_cidr": "172.16.0.0/16",
+            "subnets_configuration": [
+                {
+                    "name": "Subnet-Test",
+                    "cidr": "172.16.0.0/24"
+                }
+            ]
+        },
+        {
+            "vpc_name": "VPC-Test-1",
+            "vpc_cidr": "172.16.0.0/16",
+            "subnets_configuration": [
+                {
+                    "name": "Subnet-1-1",
+                    "cidr": "172.16.0.0/24"
+                }
+            ]
+        },
+        {
+            "vpc_name": "VPC-Test-2",
+            "vpc_cidr": "192.168.0.0/24",
+            "subnets_configuration": [
+                {
+                    "name": "Subnet-2-1",
+                    "cidr": "192.168.0.0/24"
+                }
+            ]
+        }
+    ],
+    "zone_name": "resolver.zone.name.com.",
+    "zone_type": "private",
+    "endpoint_name": "Endpoint-Test",
+    "endpoint_type": "outbound",
+    "endpoint_ip_addresses": [
+        "172.16.0.10",
+        "172.16.0.11"
+    ],
+    "resolver_rules_configuration": [
+        {
+            "name": "Rule-Test",
+            "ip_addresses": [
+                "192.168.2.100",
+                "192.168.2.101"
+            ]
+        },
+        {
+            "name": "Rule-Test2",
+            "ip_addresses": [
+                "172.168.2.100",
+                "172.168.2.101"
+            ]
+        }
+    ]
+}

--- a/examples/dns-outbound-resolver/variables.tf
+++ b/examples/dns-outbound-resolver/variables.tf
@@ -1,0 +1,80 @@
+######################################################################
+# Public configurations
+######################################################################
+
+variable "region_name" {
+  type        = string
+  description = "The region where the resources are located"
+}
+
+variable "enterprise_project_id" {
+  type        = string
+  description = "Used to specify whether the resource is created under the enterprise project (this parameter is only valid for enterprise users)"
+
+  default = ""
+}
+
+######################################################################
+# Configurations of VPC resource and related resources
+######################################################################
+
+variable "vpc_network_configurations" {
+  type = list(object({
+    vpc_name = string
+    vpc_cidr = string
+    subnets_configuration = list(object({
+      name = string
+      cidr = string
+    }))
+  }))
+
+  description = "The configuration VPCs and subnets to which the endpoint or resolver rule belongs"
+}
+
+######################################################################
+# Configurations of the zone resource
+######################################################################
+
+variable "zone_name" {
+  type        = string
+  description = "The name of the DNS zone, this parameter is optional when endpoint_type is inbound"
+
+  default = ""
+}
+
+variable "zone_type" {
+  type        = string
+  description = "The type of the DNS zone, this parameter is optional when endpoint_type is inbound"
+
+  default = null
+}
+
+######################################################################
+# Configurations endpoint resource and related resources
+######################################################################
+
+variable "endpoint_name" {
+  type        = string
+  description = "The name of the endpoint"
+}
+
+variable "endpoint_type" {
+  type        = string
+  description = "The type of the endpoint"
+}
+
+variable "endpoint_ip_addresses" {
+  type = list(string)
+
+  description = "The list of the IP addresses of the endpoint"
+}
+
+variable "resolver_rules_configuration" {
+  type = list(object({
+    name         = string
+    ip_addresses = list(string)
+  }))
+
+  description = "The basic configuration of the resolver rules, this parameter is optional when endpoint_type is inbound"
+  default     = []
+}

--- a/examples/dns-outbound-resolver/versions.tf
+++ b/examples/dns-outbound-resolver/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}

--- a/modules/dns-resolver/README.md
+++ b/modules/dns-resolver/README.md
@@ -1,0 +1,95 @@
+# Resolver management
+
+Manages the resolver resource.
+
+## Notes
+
+### How to import resources in the module structure
+
+If you want to manage an existing resolver using Terraform (otherwise why are you reading this?) you need to
+make sure that the corresponding module script has been defined in your `.tf` file, like this:
+
+```hcl
+# Manages a resolver.
+module "dns_resolver" {
+  source = "github.com/terraform-huaweicloud-modules/terraform-huaweicloud-dns/modules/dns-resolver"
+
+  ...
+}
+```
+
+Then, execute the following command to import the corresponding resource into the management of the `.tfstate` file.
+
+```bash
+$ terraform import module.dns_resolver.huaweicloud_dns_endpoint_assignment.this[0] "endpoint_id"
+
+module.dns_resolver.huaweicloud_dns_endpoint_assignment.this[0]: Importing from ID "endpoint_id"...
+module.dns_resolver.huaweicloud_dns_endpoint_assignment.this[0]: Import complete!
+  Imported huaweicloud_dns_endpoint_assignment (ID: endpoint_id)
+module.dns_resolver.huaweicloud_dns_endpoint_assignment.this[0]: Refreshing state... (ID: endpoint_id)
+
+Import successful!
+```
+
+### What should we do before deploy this module example
+
+Before manage NAT resources, the access key (AK, the corresponding environment name is `HW_ACCESS_KEY`) and the secret
+key (SK, the corresponding environment name is `HW_SECRET_KEY`) should be configured.
+
+For the linux VM, you can configure the corresponding environment variables with the following commands:
+
+```bash
+$ export HW_ACCESS_KEY=XXXXXXXXXXXXXXXXXXXX
+$ export HW_SECRET_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+Refer to this [document](https://support.huaweicloud.com/intl/en-us/devg-apisign/api-sign-provide-aksk.html) for AK/SK
+information obtain.
+
+## Contributing
+
+Report issues/questions/feature requests in the [issues](https://github.com/terraform-huaweicloud-modules/terraform-huaweicloud-dns/issues/new)
+section.
+
+Full contributing [guidelines are covered here](../../.github/how_to_contribute.md).
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| Terraform | >= 1.3.0 |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+No module.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| huaweicloud_dns_endpoint_assignment.this | resource |
+| huaweicloud_dns_resolver_rule.this | resource |
+| huaweicloud_dns_resolver_rule_associate.this | resource |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+| Name | Description | Type | Default | Required |
+|------|-------------|------|:-------:|:--------:|
+| is_endpoint_create | Controls whether a endpoint should be created | `bool` | `true` | N |
+| endpoint_name | The name of the endpoint | `string` | `""` | Y (Unless `is_endpoint_create` is specified as false) |
+| endpoint_type | The type of the endpoint | `string` | `""` | Y (Unless `is_endpoint_create` is specified as false) |
+| endpoint_assignments | The list of the IP addresses of the endpoint | <pre>list(object({<br>  subnet_id  = string<br>  ip_address = string<br>}))</pre> | <pre>[]</pre> | N |
+| resolver_rules_configuration | The configuration list of the resolver rules | <pre>list(object({<br>  endpoint_id  = optional(string, "")<br>  name         = string<br>  domain_name  = string<br>  ip_addresses = list(string)<br>}))</pre> | <pre>[]</pre> | N |
+| resolver_rule_associates_configuration | The configuration of the resolver rules associated with VPCs | <pre>list(object({<br>  resolver_rule_id = string<br>  vpc_id           = string<br>}))</pre> | <pre>[]</pre> | N |
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| endpoint_id | The ID of the endpoint |
+| endpoint_assignments | The list of assigned IP addresses under specified endpoint |
+| resolver_rules_configuration | The basic configuration list of the resolver rules |
+| resolver_rules_associate_vpcs_configuration | The VPCs associated with resolver rules |

--- a/modules/dns-resolver/main.tf
+++ b/modules/dns-resolver/main.tf
@@ -1,0 +1,54 @@
+resource "huaweicloud_dns_endpoint_assignment" "this" {
+  count = var.is_endpoint_create ? 1 : 0
+
+  name      = var.endpoint_name
+  direction = var.endpoint_type
+
+  dynamic "assignments" {
+    for_each = var.endpoint_assignments
+    content {
+      subnet_id  = assignments.value.subnet_id
+      ip_address = assignments.value.ip_address
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.endpoint_name != ""
+      error_message = "The endpoint_name is required if the is_endpoint_create is true."
+    }
+    precondition {
+      condition     = var.endpoint_type != ""
+      error_message = "The endpoint_name is required if the is_endpoint_create is true."
+    }
+  }
+}
+
+resource "huaweicloud_dns_resolver_rule" "this" {
+  count = length(var.resolver_rules_configuration)
+
+  endpoint_id = lookup(element(var.resolver_rules_configuration, count.index), "endpoint_id", "") != "" ? lookup(element(var.resolver_rules_configuration, count.index), "endpoint_id") : var.is_endpoint_create ? huaweicloud_dns_endpoint_assignment.this[0].id : ""
+  name        = lookup(element(var.resolver_rules_configuration, count.index), "name", "")
+  domain_name = lookup(element(var.resolver_rules_configuration, count.index), "domain_name", "")
+
+  # The IP addressess of the DNS in the on-premises data center.
+  dynamic "ip_addresses" {
+    for_each = lookup(element(var.resolver_rules_configuration, count.index), "ip_addresses", [])
+    content {
+      ip = ip_addresses.value
+    }
+  }
+}
+
+locals {
+  associate_vpcs_configuration = flatten([for i, o in var.resolver_rules_configuration :
+  [for v in o["vpc_ids"] : { resolver_rule_id = huaweicloud_dns_resolver_rule.this[i].id, vpc_id = v }]])
+  associates_configuration = concat(local.associate_vpcs_configuration, var.resolver_rule_associates_configuration)
+}
+
+resource "huaweicloud_dns_resolver_rule_associate" "this" {
+  count            = length(local.associates_configuration)
+  resolver_rule_id = lookup(element(local.associates_configuration, count.index), "resolver_rule_id", "")
+  # The zone name and resolver rule cannot use the same VPC ID.
+  vpc_id = lookup(element(local.associates_configuration, count.index), "vpc_id", "")
+}

--- a/modules/dns-resolver/outputs.tf
+++ b/modules/dns-resolver/outputs.tf
@@ -1,0 +1,31 @@
+output "endpoint_id" {
+  description = "The ID of the endpoint"
+
+  value = try(huaweicloud_dns_endpoint_assignment.this[0].id, "")
+}
+
+output "endpoint_assignments" {
+  description = "The list of assigned IP addresses under specified endpoint"
+
+  value = try(huaweicloud_dns_endpoint_assignment.this[0].assignments, "")
+}
+
+output "resolver_rules_configuration" {
+  description = "The basic configuration list of the resolver rules"
+
+  value = [for o in huaweicloud_dns_resolver_rule.this : {
+    "id" : o.id,
+    "domain_name" : o.domain_name,
+    "ip_addresses" : o.ip_addresses,
+  }]
+}
+
+output "resolver_rules_associate_vpcs_configuration" {
+  description = "The VPCs associated with resolver rules"
+
+  value = [for o in huaweicloud_dns_resolver_rule_associate.this : {
+    "id" : o.id,
+    "resolver_rule_id" : o.resolver_rule_id,
+    "vpc_id" : o.vpc_id,
+  }]
+}

--- a/modules/dns-resolver/variable.tf
+++ b/modules/dns-resolver/variable.tf
@@ -1,0 +1,65 @@
+######################################################################
+# Configurations of endpoint resource
+######################################################################
+
+variable "is_endpoint_create" {
+  type        = bool
+  description = "Controls whether a endpoint should be created"
+
+  default  = true
+  nullable = false
+}
+
+variable "endpoint_name" {
+  type        = string
+  description = "The name of the endpoint"
+
+  default = ""
+}
+
+variable "endpoint_type" {
+  type        = string
+  description = "The type of the endpoint"
+
+  default = ""
+}
+
+variable "endpoint_assignments" {
+  type = list(object({
+    subnet_id  = string
+    ip_address = string
+  }))
+  description = "The list of the IP addresses of the endpoint"
+
+  default  = []
+  nullable = false
+}
+
+######################################################################
+# Configurations of the resolver rule resources and related resources
+######################################################################
+
+variable "resolver_rules_configuration" {
+  type = list(object({
+    endpoint_id  = optional(string, "")
+    name         = string
+    domain_name  = string
+    ip_addresses = list(string)
+    vpc_ids      = optional(list(string), [])
+  }))
+
+  description = "The configuration list of the resolver rules and and the VPCs to associate with them"
+  default     = []
+  nullable    = false
+}
+
+variable "resolver_rule_associates_configuration" {
+  type = list(object({
+    resolver_rule_id = string
+    vpc_id           = string
+  }))
+
+  description = "The configuration of the resolver rules associated with VPCs"
+  default     = []
+  nullable    = false
+}

--- a/modules/dns-resolver/versions.tf
+++ b/modules/dns-resolver/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}


### PR DESCRIPTION
For inbound endpoint.
+ Execute `terraform apply -var-file=variables.json`  
![image](https://github.com/user-attachments/assets/869a9488-30ef-4c78-9d21-3c0f6824023b)
+ Execute `terraform plan -var-file=variables.json`
![image](https://github.com/user-attachments/assets/3a376a9c-2486-4b95-852f-18722222425b)
+ Execute `terraform destory -var-file=variables.json`
![image](https://github.com/user-attachments/assets/1589bf7e-765c-444b-9a89-9388cfa19ca9)

For outbound endpoint.
+ Execute `terraform apply -var-file=variables.json`
```
terraform apply -var-file=variables.json
data.huaweicloud_availability_zones.this: Reading...
data.huaweicloud_availability_zones.this: Read complete after 0s [id=74326821]
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.dns_resolver.huaweicloud_dns_endpoint_assignment.this[0] will be created
  + resource "huaweicloud_dns_endpoint_assignment" "this" {
      + created_at = (known after apply)
      + direction  = "outbound"
      + id         = (known after apply)
      + name       = "Endpoint-Test"
      + region     = (known after apply)
      + status     = (known after apply)
      + vpc_id     = (known after apply)
    }

  # module.dns_resolver.huaweicloud_dns_resolver_rule.this[0] will be created
  + resource "huaweicloud_dns_resolver_rule" "this" {
      + created_at  = (known after apply)
      + domain_name = "resolver.zone.name.com."
      + endpoint_id = (known after apply)
      + id          = (known after apply)
      + name        = "Rule-Test"
      + region      = (known after apply)
      + rule_type   = (known after apply)
      + status      = (known after apply)
      + updated_at  = (known after apply)
      + vpcs        = (known after apply)

      + ip_addresses {
          + ip = "192.168.2.100"
        }
      + ip_addresses {
          + ip = "192.168.2.101"
        }
    }

  # module.dns_resolver.huaweicloud_dns_resolver_rule.this[1] will be created
  + resource "huaweicloud_dns_resolver_rule" "this" {
      + created_at  = (known after apply)
      + domain_name = "resolver.zone.name.com."
      + endpoint_id = (known after apply)
      + id          = (known after apply)
      + name        = "Rule-Test2"
      + region      = (known after apply)
      + rule_type   = (known after apply)
      + status      = (known after apply)
      + updated_at  = (known after apply)
      + vpcs        = (known after apply)

      + ip_addresses {
          + ip = "172.168.2.100"
        }
      + ip_addresses {
          + ip = "172.168.2.101"
        }
    }

  # module.dns_resolver.huaweicloud_dns_resolver_rule_associate.this[0] will be created
  + resource "huaweicloud_dns_resolver_rule_associate" "this" {
      + id               = (known after apply)
      + region           = (known after apply)
      + resolver_rule_id = (known after apply)
      + status           = (known after apply)
      + vpc_id           = (known after apply)
    }

  # module.dns_resolver.huaweicloud_dns_resolver_rule_associate.this[1] will be created
  + resource "huaweicloud_dns_resolver_rule_associate" "this" {
      + id               = (known after apply)
      + region           = (known after apply)
      + resolver_rule_id = (known after apply)
      + status           = (known after apply)
      + vpc_id           = (known after apply)
    }

  # module.dns_resolver.huaweicloud_dns_resolver_rule_associate.this[2] will be created
  + resource "huaweicloud_dns_resolver_rule_associate" "this" {
      + id               = (known after apply)
      + region           = (known after apply)
      + resolver_rule_id = (known after apply)
      + status           = (known after apply)
      + vpc_id           = (known after apply)
    }

  # module.dns_resolver.huaweicloud_dns_resolver_rule_associate.this[3] will be created
  + resource "huaweicloud_dns_resolver_rule_associate" "this" {
      + id               = (known after apply)
      + region           = (known after apply)
      + resolver_rule_id = (known after apply)
      + status           = (known after apply)
      + vpc_id           = (known after apply)
    }

  # module.dns_zone.huaweicloud_dns_zone.this[0] will be created
  + resource "huaweicloud_dns_zone" "this" {
      + email                 = (known after apply)
      + enterprise_project_id = "0"
      + id                    = (known after apply)
      + masters               = (known after apply)
      + name                  = "resolver.zone.name.com."
      + proxy_pattern         = (known after apply)
      + region                = (known after apply)
      + status                = (known after apply)
      + ttl                   = 300
      + zone_type             = "private"
    }

  # module.vpc_network["0"].huaweicloud_vpc.this[0] will be created
  + resource "huaweicloud_vpc" "this" {
      + cidr                  = "172.16.0.0/16"
      + enhanced_local_route  = (known after apply)
      + enterprise_project_id = "0"
      + id                    = (known after apply)
      + name                  = "VPC-Test-Zone"
      + region                = (known after apply)
      + routes                = (known after apply)
      + secondary_cidrs       = (known after apply)
      + status                = (known after apply)
    }

  # module.vpc_network["0"].huaweicloud_vpc_subnet.this[0] will be created
  + resource "huaweicloud_vpc_subnet" "this" {
      + availability_zone = (known after apply)
      + cidr              = "172.16.0.0/24"
      + dhcp_enable       = true
      + dhcp_lease_time   = (known after apply)
      + dns_list          = (known after apply)
      + gateway_ip        = "172.16.0.1"
      + id                = (known after apply)
      + ipv4_subnet_id    = (known after apply)
      + ipv6_cidr         = (known after apply)
      + ipv6_gateway      = (known after apply)
      + ipv6_subnet_id    = (known after apply)
      + name              = "Subnet-Test"
      + primary_dns       = (known after apply)
      + region            = (known after apply)
      + secondary_dns     = (known after apply)
      + subnet_id         = (known after apply)
      + vpc_id            = (known after apply)
    }

  # module.vpc_network["1"].huaweicloud_vpc.this[0] will be created
  + resource "huaweicloud_vpc" "this" {
      + cidr                  = "172.16.0.0/16"
      + enhanced_local_route  = (known after apply)
      + enterprise_project_id = "0"
      + id                    = (known after apply)
      + name                  = "VPC-Test-1"
      + region                = (known after apply)
      + routes                = (known after apply)
      + secondary_cidrs       = (known after apply)
      + status                = (known after apply)
    }

  # module.vpc_network["1"].huaweicloud_vpc_subnet.this[0] will be created
  + resource "huaweicloud_vpc_subnet" "this" {
      + availability_zone = (known after apply)
      + cidr              = "172.16.0.0/24"
      + dhcp_enable       = true
      + dhcp_lease_time   = (known after apply)
      + dns_list          = (known after apply)
      + gateway_ip        = "172.16.0.1"
      + id                = (known after apply)
      + ipv4_subnet_id    = (known after apply)
      + ipv6_cidr         = (known after apply)
      + ipv6_gateway      = (known after apply)
      + ipv6_subnet_id    = (known after apply)
      + name              = "Subnet-1-1"
      + primary_dns       = (known after apply)
      + region            = (known after apply)
      + secondary_dns     = (known after apply)
      + subnet_id         = (known after apply)
      + vpc_id            = (known after apply)
    }

  # module.vpc_network["2"].huaweicloud_vpc.this[0] will be created
  + resource "huaweicloud_vpc" "this" {
      + cidr                  = "192.168.0.0/24"
      + enhanced_local_route  = (known after apply)
      + enterprise_project_id = "0"
      + id                    = (known after apply)
      + name                  = "VPC-Test-2"
      + region                = (known after apply)
      + routes                = (known after apply)
      + secondary_cidrs       = (known after apply)
      + status                = (known after apply)
    }

  # module.vpc_network["2"].huaweicloud_vpc_subnet.this[0] will be created
  + resource "huaweicloud_vpc_subnet" "this" {
      + availability_zone = (known after apply)
      + cidr              = "192.168.0.0/24"
      + dhcp_enable       = true
      + dhcp_lease_time   = (known after apply)
      + dns_list          = (known after apply)
      + gateway_ip        = "192.168.0.1"
      + id                = (known after apply)
      + ipv4_subnet_id    = (known after apply)
      + ipv6_cidr         = (known after apply)
      + ipv6_gateway      = (known after apply)
      + ipv6_subnet_id    = (known after apply)
      + name              = "Subnet-2-1"
      + primary_dns       = (known after apply)
      + region            = (known after apply)
      + secondary_dns     = (known after apply)
      + subnet_id         = (known after apply)
      + vpc_id            = (known after apply)
    }

Plan: 14 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + endpoint_assignments                        = (known after apply)
  + endpoint_id                                 = (known after apply)
  + resolver_rules_associate_vpcs_configuration = [
      + {
          + id               = (known after apply)
          + resolver_rule_id = (known after apply)
          + vpc_id           = (known after apply)
        },
      + {
          + id               = (known after apply)
          + resolver_rule_id = (known after apply)
          + vpc_id           = (known after apply)
        },
      + {
          + id               = (known after apply)
          + resolver_rule_id = (known after apply)
          + vpc_id           = (known after apply)
        },
      + {
          + id               = (known after apply)
          + resolver_rule_id = (known after apply)
          + vpc_id           = (known after apply)
        },
    ]
  + resolver_rules_configuration                = [
      + {
          + domain_name  = "resolver.zone.name.com."
          + id           = (known after apply)
          + ip_addresses = [
              + {
                  + ip = "192.168.2.100"
                },
              + {
                  + ip = "192.168.2.101"
                },
            ]
        },
      + {
          + domain_name  = "resolver.zone.name.com."
          + id           = (known after apply)
          + ip_addresses = [
              + {
                  + ip = "172.168.2.100"
                },
              + {
                  + ip = "172.168.2.101"
                },
            ]
        },
    ]

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.vpc_network["0"].huaweicloud_vpc.this[0]: Creating...
module.vpc_network["1"].huaweicloud_vpc.this[0]: Creating...
module.vpc_network["2"].huaweicloud_vpc.this[0]: Creating...
module.vpc_network["0"].huaweicloud_vpc.this[0]: Creation complete after 7s [id=bafec657-85c4-4b41-8f90-838fad3f7b62]
module.vpc_network["0"].huaweicloud_vpc_subnet.this[0]: Creating...
module.vpc_network["1"].huaweicloud_vpc.this[0]: Creation complete after 7s [id=e7357bff-3f7c-4033-9cc0-29af4fc6b3bf]
module.vpc_network["1"].huaweicloud_vpc_subnet.this[0]: Creating...
module.vpc_network["2"].huaweicloud_vpc.this[0]: Creation complete after 8s [id=1544ec82-e36a-4fdf-9a91-4355cba56fa2]
module.vpc_network["2"].huaweicloud_vpc_subnet.this[0]: Creating...
module.dns_zone.huaweicloud_dns_zone.this[0]: Creating...
module.dns_zone.huaweicloud_dns_zone.this[0]: Creation complete after 6s [id=ff808082955ce47d0195ebe300bd2fc4]
module.vpc_network["0"].huaweicloud_vpc_subnet.this[0]: Creation complete after 9s [id=7827a9a1-b6f8-4752-b441-e6893f3d0b7e]
module.vpc_network["1"].huaweicloud_vpc_subnet.this[0]: Still creating... [10s elapsed]
module.vpc_network["2"].huaweicloud_vpc_subnet.this[0]: Still creating... [10s elapsed]
module.vpc_network["1"].huaweicloud_vpc_subnet.this[0]: Creation complete after 12s [id=5033f5c8-9862-4d19-bcf1-a756f37ead2b]
module.vpc_network["2"].huaweicloud_vpc_subnet.this[0]: Creation complete after 15s [id=00c36a82-1bb0-4744-9d18-fe67c2bb633f]
module.dns_resolver.huaweicloud_dns_endpoint_assignment.this[0]: Creating...
module.dns_resolver.huaweicloud_dns_endpoint_assignment.this[0]: Creation complete after 7s [id=ff808082955cea550195ebe33a6540c4]
module.dns_resolver.huaweicloud_dns_resolver_rule.this[0]: Creating...
module.dns_resolver.huaweicloud_dns_resolver_rule.this[1]: Creating...
module.dns_resolver.huaweicloud_dns_resolver_rule.this[0]: Creation complete after 6s [id=ff808082955cee730195ebe3567170c1]
module.dns_resolver.huaweicloud_dns_resolver_rule.this[1]: Creation complete after 6s [id=ff808082955cf4e60195ebe3567022da]
module.dns_resolver.huaweicloud_dns_resolver_rule_associate.this[3]: Creating...
module.dns_resolver.huaweicloud_dns_resolver_rule_associate.this[2]: Creating...
module.dns_resolver.huaweicloud_dns_resolver_rule_associate.this[1]: Creating...
module.dns_resolver.huaweicloud_dns_resolver_rule_associate.this[0]: Creating...
module.dns_resolver.huaweicloud_dns_resolver_rule_associate.this[2]: Creation complete after 6s [id=ff808082955cf4e60195ebe3567022da/e7357bff-3f7c-4033-9cc0-29af4fc6b3bf]
module.dns_resolver.huaweicloud_dns_resolver_rule_associate.this[1]: Creation complete after 6s [id=ff808082955cee730195ebe3567170c1/1544ec82-e36a-4fdf-9a91-4355cba56fa2]
module.dns_resolver.huaweicloud_dns_resolver_rule_associate.this[0]: Creation complete after 7s [id=ff808082955cee730195ebe3567170c1/e7357bff-3f7c-4033-9cc0-29af4fc6b3bf]
module.dns_resolver.huaweicloud_dns_resolver_rule_associate.this[3]: Creation complete after 7s [id=ff808082955cf4e60195ebe3567022da/1544ec82-e36a-4fdf-9a91-4355cba56fa2]

Apply complete! Resources: 14 added, 0 changed, 0 destroyed.

Outputs:

endpoint_assignments = toset([
  {
    "ip_address" = "172.16.0.10"
    "ip_address_id" = "ff808082955cea550195ebe33a6540c6"
    "subnet_id" = "7827a9a1-b6f8-4752-b441-e6893f3d0b7e"
  },
  {
    "ip_address" = "172.16.0.11"
    "ip_address_id" = "ff808082955cea550195ebe33a6540c5"
    "subnet_id" = "7827a9a1-b6f8-4752-b441-e6893f3d0b7e"
  },
])
endpoint_id = "ff808082955cea550195ebe33a6540c4"
resolver_rules_associate_vpcs_configuration = [
  {
    "id" = "ff808082955cee730195ebe3567170c1/e7357bff-3f7c-4033-9cc0-29af4fc6b3bf"
    "resolver_rule_id" = "ff808082955cee730195ebe3567170c1"
    "vpc_id" = "e7357bff-3f7c-4033-9cc0-29af4fc6b3bf"
  },
  {
    "id" = "ff808082955cee730195ebe3567170c1/1544ec82-e36a-4fdf-9a91-4355cba56fa2"
    "resolver_rule_id" = "ff808082955cee730195ebe3567170c1"
    "vpc_id" = "1544ec82-e36a-4fdf-9a91-4355cba56fa2"
  },
  {
    "id" = "ff808082955cf4e60195ebe3567022da/e7357bff-3f7c-4033-9cc0-29af4fc6b3bf"
    "resolver_rule_id" = "ff808082955cf4e60195ebe3567022da"
    "vpc_id" = "e7357bff-3f7c-4033-9cc0-29af4fc6b3bf"
  },
  {
    "id" = "ff808082955cf4e60195ebe3567022da/1544ec82-e36a-4fdf-9a91-4355cba56fa2"
    "resolver_rule_id" = "ff808082955cf4e60195ebe3567022da"
    "vpc_id" = "1544ec82-e36a-4fdf-9a91-4355cba56fa2"
  },
]
resolver_rules_configuration = [
  {
    "domain_name" = "resolver.zone.name.com."
    "id" = "ff808082955cee730195ebe3567170c1"
    "ip_addresses" = toset([
      {
        "ip" = "192.168.2.100"
      },
      {
        "ip" = "192.168.2.101"
      },
    ])
  },
  {
    "domain_name" = "resolver.zone.name.com."
    "id" = "ff808082955cf4e60195ebe3567022da"
    "ip_addresses" = toset([
      {
        "ip" = "172.168.2.100"
      },
      {
        "ip" = "172.168.2.101"
      },
    ])
  },
]
```
+ Execute `terraform plan -var-file=variables.json`
![image](https://github.com/user-attachments/assets/393b84cf-7a5c-4969-9bbf-282187dbf95e)
+ Execute `terraform destory -var-file=variables.json`
![image](https://github.com/user-attachments/assets/1a828ace-1049-4f11-8e35-777c25542a25)
